### PR TITLE
ci: let a release go out unsigned until SignPath approves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ permissions:
 env:
   SIGNPATH_PROJECT_SLUG: autotidy
   SIGNPATH_SIGNING_POLICY_SLUG: release-signing
+  # Signing is opt-in on the secrets being present. The SignPath Foundation
+  # application is still pending, and a workflow that cannot cut a release until
+  # a third party approves an application is a workflow that cannot cut a
+  # release. Unsigned builds go out with the signing steps skipped, and start
+  # being signed the moment the secrets exist — no edit required.
+  SIGNING_ENABLED: ${{ secrets.SIGNPATH_API_TOKEN != '' && secrets.SIGNPATH_ORG_ID != '' }}
 
 jobs:
   release:
@@ -100,6 +106,7 @@ jobs:
 
       - name: Upload the unsigned executable
         id: unsigned-exe
+        if: env.SIGNING_ENABLED == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-exe
@@ -107,6 +114,7 @@ jobs:
 
       # --- 2. Sign it (approval #1) -----------------------------------------
       - name: Sign the executable
+        if: env.SIGNING_ENABLED == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -117,8 +125,9 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: signed-exe
 
-      # --- 3. Bundle the SIGNED executable ----------------------------------
+      # --- 3. Bundle the (signed, when signing ran) executable --------------
       - name: Put the signed executable back
+        if: env.SIGNING_ENABLED == 'true'
         run: Copy-Item signed-exe/AutoTidy.exe target/release/AutoTidy.exe -Force
 
       - name: Bundle the installer
@@ -131,6 +140,7 @@ jobs:
 
       - name: Upload the unsigned installer
         id: unsigned-installer
+        if: env.SIGNING_ENABLED == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-installer
@@ -138,6 +148,7 @@ jobs:
 
       # --- 4. Sign the installer (approval #2) ------------------------------
       - name: Sign the installer
+        if: env.SIGNING_ENABLED == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -149,13 +160,29 @@ jobs:
           output-artifact-directory: signed-installer
 
       # --- 5. Publish -------------------------------------------------------
-      # The checksum is computed from the signed file the user will actually
-      # download; taking it any earlier would publish a hash that never matches.
+      # Collect whatever the run actually produced into one directory, so the
+      # publish step below is identical whether or not signing happened.
+      - name: Collect the release files
+        run: |
+          New-Item -ItemType Directory -Force release | Out-Null
+          if ("${{ env.SIGNING_ENABLED }}" -eq "true") {
+            Copy-Item signed-installer/*.exe release/
+            Copy-Item signed-exe/AutoTidy.exe release/
+          } else {
+            Write-Host "::warning::SignPath secrets are not configured - publishing UNSIGNED binaries."
+            Copy-Item unsigned-installer/*.exe release/
+            Copy-Item target/release/AutoTidy.exe release/
+          }
+          Get-ChildItem release | Select-Object Name, Length
+
+      # Checksums come from the exact files being attached to the release. Taken
+      # any earlier — before signing, say — they would never match what a user
+      # actually downloads.
       - name: Checksums
         run: |
-          Get-ChildItem signed-installer/*.exe | ForEach-Object {
+          Get-ChildItem release/*.exe | ForEach-Object {
             $h = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
-            "$h  $($_.Name)" | Out-File -Append -Encoding utf8 signed-installer/SHA256SUMS.txt
+            "$h  $($_.Name)" | Out-File -Append -Encoding utf8 release/SHA256SUMS.txt
             Write-Host "$h  $($_.Name)"
           }
 
@@ -165,5 +192,5 @@ jobs:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           draft: true # reviewed by a human before it goes live
           files: |
-            signed-installer/*.exe
-            signed-installer/SHA256SUMS.txt
+            release/*.exe
+            release/SHA256SUMS.txt

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -385,13 +385,20 @@ fn build_rule_templates(folders: &UserFolders) -> serde_json::Value {
         {
             "category": "Photos & video",
             "name": "Sort screenshots into dated folders",
-            "description": "Screenshots move out of Pictures\\Screenshots into a folder named for the month they were filed. There's no age limit — this runs on every scan.",
+            "description": "Screenshots move into 'Screenshots\\Sorted', under a folder named for the month they were filed. There's no age limit — this runs on every scan.",
             "rules": [template_rule(
                 &screenshots,
                 "*.{png,jpg,jpeg}",
                 0,
                 "move",
-                Some(screenshots.join("{YYYY}-{MM}")),
+                // Not `Screenshots\{YYYY}-{MM}` directly: a destination whose
+                // placeholder-free prefix *is* the monitored folder makes
+                // `guard_paths` prune the folder it was asked to scan, and the
+                // rule silently stops matching anything once the user turns on
+                // recursive scanning. The named level in between is what keeps
+                // the guard below the root. See `template_guards_never_prune_
+                // the_folder_being_watched`.
+                Some(screenshots.join("Sorted").join("{YYYY}-{MM}")),
                 &[],
             )],
         },
@@ -1475,6 +1482,31 @@ mod tests {
             assert!(rule.enabled);
             autotidy_core::rule::CompiledRule::compile(&rule)
                 .unwrap_or_else(|e| panic!("{}: {e}", rule.pattern));
+        }
+    }
+
+    /// A move rule's own destination is pruned from its walk, so it never
+    /// re-processes what it just filed. The prune target is the destination's
+    /// deepest placeholder-free prefix — which, for a destination like
+    /// `…\Screenshots\{YYYY}-{MM}`, is `…\Screenshots`: the monitored folder
+    /// itself. That prunes the walk at its root, and the rule quietly matches
+    /// nothing at all the moment recursive scanning is switched on.
+    ///
+    /// Flat scanning (the default) does not consult the guards, so a template
+    /// with this shape looks perfectly healthy until a user changes an unrelated
+    /// setting. Hence a test rather than a comment.
+    #[test]
+    fn template_guards_never_prune_the_folder_being_watched() {
+        let templates = test_templates();
+        for value in every_rule(&templates) {
+            let rule: autotidy_core::config::Rule = serde_json::from_value(value.clone()).unwrap();
+            let monitored = Path::new(&rule.path);
+            let guards = guard_paths(&rule, &rule.destination_folder, monitored);
+            assert!(
+                !guards.contains(&autotidy_core::config::normalize(monitored)),
+                "{} would prune its own monitored folder",
+                rule.path
+            );
         }
     }
 


### PR DESCRIPTION
`release.yml` called SignPath unconditionally, so pushing a `v2.0.0` tag today would run the full build, reach the signing step, and fail — the Foundation application is pending and the secrets don't exist.

Signing is now gated on `secrets.SIGNPATH_API_TOKEN` and `SIGNPATH_ORG_ID` being present:

- **absent** → signing steps skip, job warns `SignPath secrets are not configured - publishing UNSIGNED binaries`, release still publishes
- **present** → signs exactly as before, no edit needed

Both paths collect into one `release/` directory so the publish step is identical, and checksums are computed from the files actually attached (taking them pre-signing would publish hashes that never match).

Also attaches `AutoTidy.exe` alongside the installer, restoring the portable build 1.5.0 shipped.

Raising this as a PR rather than pushing to `main` — the branch protection rule asks for it.