### PR TITLE
ci: write SHA256SUMS with LF so sha256sum -c can read it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,11 +180,20 @@ jobs:
       # actually downloads.
       - name: Checksums
         run: |
-          Get-ChildItem release/*.exe | ForEach-Object {
-            $h = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
-            "$h  $($_.Name)" | Out-File -Append -Encoding utf8 release/SHA256SUMS.txt
+          # Written with explicit LF and no BOM. PowerShell's Out-File emits
+          # CRLF, which puts a trailing CR inside the *filename* as far as
+          # `sha256sum -c` is concerned, so every line fails with
+          # "No such file or directory" — on a file whose whole purpose is
+          # letting people verify a download they were told not to trust.
+          $lines = Get-ChildItem release/*.exe | ForEach-Object {
+            $h = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
             Write-Host "$h  $($_.Name)"
+            "$h  $($_.Name)"
           }
+          [IO.File]::WriteAllText(
+            "$PWD/release/SHA256SUMS.txt",
+            ($lines -join "`n") + "`n",
+            (New-Object Text.UTF8Encoding $false))
 
       - name: Publish the release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
PowerShell's `Out-File` emits CRLF, so `sha256sum -c` reads the trailing CR as part of the **filename**:

```
sha256sum: 'AutoTidy_2.0.0_x64-setup.exe'$'\r': No such file or directory
AutoTidy_2.0.0_x64-setup.exe: FAILED open or read
```

Caught on the v2.0.0 draft. The hashes were correct — the file was just unusable by the standard tool, on the one artifact whose entire purpose is letting someone verify a download we tell them not to trust (unsigned, SmartScreen will warn).

Now written with `WriteAllText`, explicit LF, no BOM, and lowercased to match `sha256sum`'s own output format. Verified locally: `sha256sum -c` passes.

The v2.0.0 release asset has already been regenerated and re-uploaded, so the current draft is correct.